### PR TITLE
Increase flexibility by decoupling hawk signing from `.hawk()` call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-hawk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "adds hawk to superagent",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superagent-hawk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "adds hawk to superagent",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change increases the flexibility regarding when `.hawk()` must be called.

Before this change the request header was generated and added to the request directly in the `.hawk()` method. After the change calling `.hawk()` only enables request signing, but the generation of the header is done later when `.end()` is called. This means that the order in which `.hawk()` and other methods that might be called on a request object doesn't matter anymore, as long as `.end()` is called last.