### PR TITLE
Fix TypeError when a network error occurs

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,20 +55,20 @@ module.exports = function (superagent) {
     return hawk_header.artifacts;
   };
 
-  var verify_hawk_response = function(result, credential, artifacts) {
+  var verify_hawk_response = function(err, res, credential, artifacts) {
     var hawk_options = {
-      payload: result.res.text,
+      payload: res.text,
       required: true
     }
 
     var verified =  hawk.client.authenticate(
-        result,
+        res,
         credential,
         artifacts,
         hawk_options);
 
     if (!verified) {
-      result.error = new Error(
+      res.error = new Error(
           'Hawk response signature verification failed');
     }
   }
@@ -84,7 +84,9 @@ module.exports = function (superagent) {
       if (this._enable_hawk_response_verification) {
         var hawk_credential = this._hawk_credential;
         var wrapped_response_handler = function(err, res) {
-          verify_hawk_response(res, hawk_credential, artifacts);
+          if (res) {
+            verify_hawk_response(err, res, hawk_credential, artifacts);
+          }
           if (2 == response_handler.length) return response_handler(err, res);
           if (err) return this.emit('error', err);
           return response_handler(res);


### PR DESCRIPTION
Currently there is an issue if a network error occurs, because the signature verification code is run against an empty `res` variable resulting in a TypeError being raised.

This patch corrects that issue by only verifying the server signature if there was a response from the server, and also passes the `err` element provided by superagent through to the verification callback to be consistent with the way superagent handles response callbacks.